### PR TITLE
feat!: update `aria-live-capture` to ESM-only version

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,26 @@ npm install --save-dev extend-to-be-announced
 
 ### Test setup
 
-There are out-of-the-box setups for Jest and Vitest.
+There are out-of-the-box setups for Vitest and Jest.
+
+#### Vitest
+
+Import registration entrypoint in your [test setup](https://vitest.dev/config/#setupfiles).
+
+```js
+import 'extend-to-be-announced/vitest';
+```
+
+For setting up registration options use `register(options)` method instead.
+
+```js
+import { register } from 'extend-to-be-announced/vitest/register';
+
+register({
+    /** Indicates whether live regions inside `ShadowRoot`s should be tracked. Defaults to false. */
+    includeShadowDom: true,
+});
+```
 
 #### Jest
 
@@ -91,23 +110,10 @@ register({
 });
 ```
 
-#### Vitest
-
-Import registration entrypoint in your [test setup](https://vitest.dev/config/#setupfiles).
+Note that you'll need to add ESM dependencies of this package to your Jest config's `transformIgnorePatterns`. For example with `pnpm`:
 
 ```js
-import 'extend-to-be-announced/vitest';
-```
-
-For setting up registration options use `register(options)` method instead.
-
-```js
-import { register } from 'extend-to-be-announced/vitest/register';
-
-register({
-    /** Indicates whether live regions inside `ShadowRoot`s should be tracked. Defaults to false. */
-    includeShadowDom: true,
-});
+transformIgnorePatterns: ['/node_modules/.pnpm/(?!(aria-live-capture)@)'],
 ```
 
 ### Typescript

--- a/README.md
+++ b/README.md
@@ -99,21 +99,6 @@ Import registration entrypoint in your [test setup](https://vitest.dev/config/#s
 import 'extend-to-be-announced/vitest';
 ```
 
-Vitest also requires all dependencies that `import` Vitest internally to be inlined. Add `extend-to-be-announced` to your configuration's `test.deps.inline` array:
-
-```js
-// vitest.config.ts
-import { defineConfig } from 'vitest/config';
-
-export default defineConfig({
-    test: {
-        deps: {
-            inline: ['extend-to-be-announced'],
-        },
-    },
-});
-```
-
 For setting up registration options use `register(options)` method instead.
 
 ```js

--- a/examples/example-create-react-app/package.json
+++ b/examples/example-create-react-app/package.json
@@ -15,5 +15,10 @@
         "react-dom": "^18.2.0",
         "react-scripts": "^5.0.1",
         "typescript": "^4.9.4"
+    },
+    "jest": {
+        "transformIgnorePatterns": [
+            "/node_modules/.pnpm/(?!(aria-live-capture)@)"
+        ]
     }
 }

--- a/examples/example-jest-shadow-dom/jest.config.js
+++ b/examples/example-jest-shadow-dom/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-    preset: 'ts-jest',
+    preset: 'ts-jest/presets/js-with-ts',
     testEnvironment: 'jsdom',
     setupFilesAfterEnv: ['./setup.ts'],
+    transformIgnorePatterns: ['/node_modules/.pnpm/(?!(aria-live-capture)@)'],
 };

--- a/examples/example-jest-shadow-dom/tsconfig.json
+++ b/examples/example-jest-shadow-dom/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "CommonJS",
         "target": "ESNext",
         "moduleResolution": "Node16",
+        "allowJs": true,
         "noEmit": true,
         "skipLibCheck": true
     }

--- a/examples/example-jest/jest.config.js
+++ b/examples/example-jest/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-    preset: 'ts-jest',
+    preset: 'ts-jest/presets/js-with-ts',
     testEnvironment: 'jsdom',
     setupFilesAfterEnv: ['./setup.ts'],
+    transformIgnorePatterns: ['/node_modules/.pnpm/(?!(aria-live-capture)@)'],
 };

--- a/examples/example-jest/tsconfig.json
+++ b/examples/example-jest/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "CommonJS",
         "target": "ESNext",
         "moduleResolution": "Node16",
+        "allowJs": true,
         "noEmit": true,
         "skipLibCheck": true
     }

--- a/examples/example-vitest-shadow-dom/vitest.config.ts
+++ b/examples/example-vitest-shadow-dom/vitest.config.ts
@@ -5,8 +5,5 @@ export default defineConfig({
         environment: 'jsdom',
         reporters: 'verbose',
         setupFiles: ['./setup.ts'],
-        deps: {
-            inline: ['extend-to-be-announced'],
-        },
     },
 });

--- a/examples/example-vitest/vitest.config.ts
+++ b/examples/example-vitest/vitest.config.ts
@@ -5,8 +5,5 @@ export default defineConfig({
         environment: 'jsdom',
         reporters: 'verbose',
         setupFiles: ['./setup.ts'],
-        deps: {
-            inline: ['extend-to-be-announced'],
-        },
     },
 });

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "homepage": "https://github.com/AriPerkkio/extend-to-be-announced",
     "bugs": "https://github.com/AriPerkkio/extend-to-be-announced",
     "dependencies": {
-        "aria-live-capture": "^1.0.2"
+        "aria-live-capture": "^2.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       aria-live-capture:
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.2.0
@@ -634,8 +634,8 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aria-live-capture@1.0.2:
-    resolution: {integrity: sha512-qkRstEzhec0TWLhrjZh7uJM7ITaRr/WbJRp4xg7iupWkC3TE0oLaIDGWZ9QpBe+UZh71xNQq7FPlWfF1GXwefw==}
+  aria-live-capture@2.0.0:
+    resolution: {integrity: sha512-h2c193NGHIvPJqbVJwrX+Yyn2ir6z2CLokfrqczSReVgEl89PtwYqT0DA3Sw6+Anb6Awq7Mv9o1uTbiipkvh3w==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -2108,7 +2108,7 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  aria-live-capture@1.0.2: {}
+  aria-live-capture@2.0.0: {}
 
   array-union@2.1.0: {}
 


### PR DESCRIPTION
- Breaking changes for Jest users: `transformIgnorePatterns` has to be configured to transform `aria-live-capture`. 